### PR TITLE
NegBioPtb2DepConverter constructor update

### DIFF
--- a/stages/classify.py
+++ b/stages/classify.py
@@ -79,8 +79,8 @@ class Classifier(object):
     def __init__(self, pre_negation_uncertainty_path, negation_path,
                  post_negation_uncertainty_path, verbose=False):
         self.parser = parse.NegBioParser(model_dir=PARSING_MODEL_DIR)
-        self.ptb2dep = ptb2ud.NegBioPtb2DepConverter(universal=True)
         self.lemmatizer = ptb2ud.Lemmatizer()
+        self.ptb2dep = ptb2ud.NegBioPtb2DepConverter(self.lemmatizer, universal=True)
 
         self.verbose = verbose
 


### PR DESCRIPTION
When running `python label.py --reports_path sample_reports.csv`, the following error appears:
```
Traceback (most recent call last):
  File "label.py", line 51, in <module>
    label(parser.parse_args())
  File "label.py", line 33, in label
    verbose=args.verbose)
  File "chexpert-labeler/stages/classify.py", line 82, in __init__
    self.ptb2dep = ptb2ud.NegBioPtb2DepConverter(universal=True)
TypeError: __init__() missing 1 required positional argument: 'lemmatizer'
```

This error is due to an update in the constructor of NegBioPtb2DepConverter:
```
class NegBioPtb2DepConverter(Ptb2DepConverter):
    def __init__(self, lemmatizer, representation='CCprocessed', universal=False):
        """
        Args:
            lemmatizer (Lemmatizer)
        """
        super(NegBioPtb2DepConverter, self).__init__(lemmatizer, representation, universal)
```
https://github.com/ncbi-nlp/NegBio/blob/master/negbio/pipeline/ptb2ud.py#L95-L101

This fix includes the defined lemmatizer and addresses issue #6.