### PR TITLE
rem empty sentences from report before processing

### DIFF
--- a/loader/load.py
+++ b/loader/load.py
@@ -79,5 +79,7 @@ class Loader(object):
         clean_report = clean_report.translate(self.punctuation_spacer)
         # Convert any multi white spaces to single white spaces.
         clean_report = ' '.join(clean_report.split())
+        # Remove empty sentences
+        clean_report = re.sub(r'\.\s+\.', '.', clean_report)
 
         return clean_report


### PR DESCRIPTION
I have run into a few reports with misaligned punctuation e.g. `Lungs are clear. .` which later gives a vague downstream error unable to parse sentence tree for the empty sentence `.`. This fix cleans out those sentences (the end result doesn't change the output of the labeler but it does stop it from printing out worrying error messages!).